### PR TITLE
feat: redirect cart api url to bff

### DIFF
--- a/src/components/MainLayout/components/Cart.tsx
+++ b/src/components/MainLayout/components/Cart.tsx
@@ -12,7 +12,7 @@ export default function Cart() {
   const dispatch = useDispatch();
   useEffect(() => {
     axios.get(
-        `${API_PATHS.cart}/profile/cart`,
+        `${API_PATHS.bff}/profile/cart`,
         {
           headers: {
             Authorization: `Basic ${localStorage.getItem('authorization_token')}`

--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -3,8 +3,7 @@ const API_PATHS = {
   product: 'https://fw3b67j1u8.execute-api.eu-central-1.amazonaws.com/dev',
   order: 'https://fw3b67j1u8.execute-api.eu-central-1.amazonaws.com/dev',
   import: 'https://jra3ihgafh.execute-api.eu-central-1.amazonaws.com/dev',
-  bff: 'https://fw3b67j1u8.execute-api.eu-central-1.amazonaws.com/dev',
-  cart: 'http://alimovdavron-cart-api-develop.eu-central-1.elasticbeanstalk.com/api',
+  bff: 'http://alimovdavron-bff-service-dev.eu-central-1.elasticbeanstalk.com',
 };
 
 export default API_PATHS;

--- a/src/store/cartSlice.ts
+++ b/src/store/cartSlice.ts
@@ -56,7 +56,7 @@ export const cartSlice = createSlice({
 export const addToCart = (product: Product) => async (dispatch: any, getState: any) => {
   dispatch(cartSlice.actions.addToCart(product));
   const { cart: { items } } = getState();
-  await axios.put(`${API_PATHS.cart}/profile/cart`, { items }, {
+  await axios.put(`${API_PATHS.bff}/profile/cart`, { items }, {
     headers: {
       Authorization: `Basic ${localStorage.getItem('authorization_token')}`,
     },
@@ -66,7 +66,7 @@ export const addToCart = (product: Product) => async (dispatch: any, getState: a
 export const removeFromCart = (product: Product) => async (dispatch: any, getState: any) => {
   dispatch(cartSlice.actions.removeFromCart(product));
   const { cart: { items } } = getState();
-  await axios.put(`${API_PATHS.cart}/profile/cart`, { items }, {
+  await axios.put(`${API_PATHS.bff}/profile/cart`, { items }, {
     headers: {
       Authorization: `Basic ${localStorage.getItem('authorization_token')}`,
     },
@@ -76,7 +76,7 @@ export const removeFromCart = (product: Product) => async (dispatch: any, getSta
 export const clearCart = () => async (dispatch: any, getState: any) => {
   dispatch(cartSlice.actions.clearCart());
   const { cart: { items } } = getState();
-  await axios.put(`${API_PATHS.cart}/profile/cart`, { items }, {
+  await axios.put(`${API_PATHS.bff}/profile/cart`, { items }, {
     headers: {
       Authorization: `Basic ${localStorage.getItem('authorization_token')}`,
     },


### PR DESCRIPTION
**Link to the CloudFront distribution** https://d1s4qelxm95ilt.cloudfront.net/

Please note that cart api is under **profile** prefix in the bff, not **cart**